### PR TITLE
@ResponseStatus -> ResponseEntity로 통일

### DIFF
--- a/src/main/java/project/myblog/web/MemberController.java
+++ b/src/main/java/project/myblog/web/MemberController.java
@@ -2,19 +2,18 @@ package project.myblog.web;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import project.myblog.auth.dto.Login;
 import project.myblog.auth.dto.LoginMember;
-import project.myblog.domain.Member;
 import project.myblog.service.member.MemberService;
 import project.myblog.web.dto.member.request.MemberIntroductionRequest;
-import project.myblog.web.dto.member.response.MemberResponse;
 import project.myblog.web.dto.member.request.MemberSubjectRequest;
+import project.myblog.web.dto.member.response.MemberResponse;
 
 import javax.validation.Valid;
 
@@ -27,27 +26,28 @@ public class MemberController {
     }
 
     @GetMapping(value = "/members/me", produces = MediaType.APPLICATION_JSON_VALUE)
-    public MemberResponse findMemberOfMine(@Login LoginMember loginMember) {
-        return memberService.findMemberOfMine(loginMember.getEmail());
+    public ResponseEntity<MemberResponse> findMemberOfMine(@Login LoginMember loginMember) {
+        MemberResponse member = memberService.findMemberOfMine(loginMember.getEmail());
+        return ResponseEntity.ok(member);
     }
 
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PatchMapping(value = "/members/me/introduction", produces = MediaType.APPLICATION_JSON_VALUE)
-    public void updateMemberOfMineIntroduction(@Login LoginMember loginMember,
-                                               @Valid @RequestBody MemberIntroductionRequest request) {
+    public ResponseEntity<Void> updateMemberOfMineIntroduction(@Login LoginMember loginMember,
+                                                         @Valid @RequestBody MemberIntroductionRequest request) {
         memberService.updateMemberOfMineIntroduction(loginMember.getEmail(), request.getIntroduction());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PatchMapping(value = "/members/me/subject", produces = MediaType.APPLICATION_JSON_VALUE)
-    public void updateMemberOfMineSubject(@Login LoginMember loginMember,
-                                          @Valid @RequestBody MemberSubjectRequest request) {
+    public ResponseEntity<Void> updateMemberOfMineSubject(@Login LoginMember loginMember,
+                                                            @Valid @RequestBody MemberSubjectRequest request) {
         memberService.updateMemberOfMineSubject(loginMember.getEmail(), request.getSubject());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping(value = "/members/me")
-    public void deleteMember(@Login LoginMember loginMember) {
-
+    public ResponseEntity<Void> deleteMember(@Login LoginMember loginMember) {
+        memberService.deleteMember(loginMember.getEmail());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }


### PR DESCRIPTION
이유: 케이스 별로 상태 변경이 필요할 수도 있고, Location 생성이 필요할 수 있는 등
유연하게 대처하기 위해서 @ResponseStatus와 섞어 쓰는 것 보다는 하나로 통일 하는 것이 가독성이 좋다고 생각하기 때문에